### PR TITLE
chore: Dockerfile에서 jar파일 경로 상대 경로로 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:17-alpine
 
-ARG JAR_FILE=/build/libs/clothstar-0.0.1-SNAPSHOT.jar
+ARG JAR_FILE=build/libs/clothstar-0.0.1-SNAPSHOT.jar
 
 COPY ${JAR_FILE} app.jar
 


### PR DESCRIPTION
- Docker 빌드 컨텍스트 내에서 build/libs/clothstar-0.0.1-SNAPSHOT.jar 경로를 Dockerfile 위치 기준으로 찾을 수 있도록 상대 경로로 변경