### PR TITLE
chore: home/ubuntu/로 복사 후 SSH를 사용해 sudo로 파일을 /etc/nginx/conf.d/로 이동

### DIFF
--- a/.github/workflows/dev-aws-CI-CD.yml
+++ b/.github/workflows/dev-aws-CI-CD.yml
@@ -75,23 +75,26 @@ jobs:
       - name: Show docker-compose.yml Content
         run: cat docker-compose.yml  # docker-compose.yml 파일 내용 확인
 
-      - name: Send docker-compose.yml
-        uses: appleboy/scp-action@master
-        with:
-          username: ubuntu
-          host: ${{ secrets.AWS_DEV_HOSTNAME }}
-          key: ${{ secrets.AWS_DEV_PRIVATE_KEY }}
-          source: "./docker-compose.yml"
-          target: "/home/ubuntu/"
-
-      - name: Send nginx.conf
+      # Send nginx.conf to a temporary location
+      - name: Send nginx.conf to Home Directory
         uses: appleboy/scp-action@master
         with:
           username: ubuntu
           host: ${{ secrets.AWS_DEV_HOSTNAME }}
           key: ${{ secrets.AWS_DEV_PRIVATE_KEY }}
           source: "./nginx/conf.d/nginx.conf"
-          target: "/etc/nginx/conf.d/"
+          target: "/home/ubuntu/"
+
+      # Move nginx.conf from Home Directory to /etc/nginx/conf.d
+      - name: Move nginx.conf to /etc/nginx/conf.d
+        uses: appleboy/ssh-action@master
+        with:
+          username: ubuntu
+          host: ${{ secrets.AWS_DEV_HOSTNAME }}
+          key: ${{ secrets.AWS_DEV_PRIVATE_KEY }}
+          script: |
+            sudo mkdir -p /etc/nginx/conf.d/
+            sudo mv /home/ubuntu/nginx.conf /etc/nginx/conf.d/nginx.conf
 
       ## Docker login
       - name: Docker Login


### PR DESCRIPTION
	1.	권한 문제: /etc/nginx/conf.d/는 시스템 디렉토리로, 일반 사용자(예: ubuntu)는 해당 디렉토리에 쓸 권한이 없습니다. 따라서 scp-action에서 sudo 없이 해당 디렉토리에 파일을 복사할 수 없습니다.
	2.	경로 접근 문제: scp-action으로 복사한 후, sudo 권한을 사용해 적절한 위치로 파일을 이동해야 합니다.